### PR TITLE
[DOC-340] added example from docs

### DIFF
--- a/ReferenceManual/HookReentrancy/Example.sol
+++ b/ReferenceManual/HookReentrancy/Example.sol
@@ -1,0 +1,19 @@
+contract Example {
+  uint public x;
+  function updateX() external {
+    x = 3;
+  }
+
+  function foo() external {
+    myInternalFoo();
+  }
+
+  function myInternalFoo() internal {
+    // ...
+  }
+
+  function bar() external {
+    x = 5;
+  }
+
+}

--- a/ReferenceManual/HookReentrancy/HookReentrancy.conf
+++ b/ReferenceManual/HookReentrancy/HookReentrancy.conf
@@ -1,0 +1,8 @@
+{
+    "files": [
+        "Example.sol"
+    ],
+    "process": "emv",
+    "solc": "solc8.16",
+    "verify": "Example:HookReentrancy.spec"
+}

--- a/ReferenceManual/HookReentrancy/HookReentrancy.spec
+++ b/ReferenceManual/HookReentrancy/HookReentrancy.spec
@@ -1,0 +1,34 @@
+// In this test, we have the following sequence of events:
+// rule
+//   updateX()
+//     assign to x, triggering hook
+//       update xStoreCount
+//       updateX()
+//         assign to x, shouldn't trigger hook since hook is running
+//
+// See https://docs.certora.com/en/latest/docs/cvl/hooks.html#recursive-hooks
+
+methods {
+    function updateX() external envfree;
+}
+
+/// the number of stores to `x`
+ghost mathint xStoreCount;
+
+/// increment xStoreCount and recursively update `x`
+hook Sstore x uint v STORAGE {
+    xStoreCount = xStoreCount + 1;
+    if (xStoreCount < 5) {
+        updateX();
+    }
+}
+
+/// This rule will pass because hooks are not recursively applied
+rule checkStoreCount {
+    require xStoreCount == 0;
+    updateX();
+    assert xStoreCount == 1;
+    updateX();
+    assert xStoreCount == 2;
+}
+


### PR DESCRIPTION
Added an example from the reference manual.  The link in the comment points to a header that is defined in https://github.com/Certora/Documentation/pull/148.