### PR TITLE
Dispatch list triggers fallback

### DIFF
--- a/CVLByExample/UnresolvedCallSummarization/WithFallback/Implementation.sol
+++ b/CVLByExample/UnresolvedCallSummarization/WithFallback/Implementation.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+contract Implementation {
+    function addition(uint256 x, uint256 y) external pure returns (uint256) {
+        return x + y;
+    }
+}

--- a/CVLByExample/UnresolvedCallSummarization/WithFallback/Proxy.sol
+++ b/CVLByExample/UnresolvedCallSummarization/WithFallback/Proxy.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+contract Proxy {
+    address internal _implementation;
+    constructor(address implementation) {
+        _implementation = implementation;
+    }
+
+    fallback() external {
+        // This code is for "illustration" purposes. To implement this functionality in production it
+        // is recommended to use the `Proxy` contract from the `@openzeppelin/contracts` library.
+        // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.8.2/contracts/proxy/Proxy.sol
+        
+        address implementation = _implementation;
+        assembly {
+            // (1) copy incoming call data
+            calldatacopy(0, 0, calldatasize())
+
+            // (2) forward call to logic contract
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            // (3) retrieve return data
+            returndatacopy(0, 0, returndatasize())
+
+            // (4) forward return data back to caller
+            switch result
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+}

--- a/CVLByExample/UnresolvedCallSummarization/WithFallback/ProxySimulator.sol
+++ b/CVLByExample/UnresolvedCallSummarization/WithFallback/ProxySimulator.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+contract ProxySimulator {
+    function callAddition(address proxy, uint32 methodsig, uint256 x, uint256 y) external view returns (uint256) {
+        (bool success, bytes memory data) = proxy.staticcall(abi.encodePacked(methodsig, x, y));
+        
+        require(success);
+
+        return abi.decode(data, (uint256));
+    }
+}

--- a/CVLByExample/UnresolvedCallSummarization/WithFallback/WithFallback.conf
+++ b/CVLByExample/UnresolvedCallSummarization/WithFallback/WithFallback.conf
@@ -1,0 +1,13 @@
+{
+    "files": [
+        "ProxySimulator.sol",
+        "Proxy.sol",
+        "Implementation.sol"
+    ],
+    "link": [
+        "Proxy:_implementation=Implementation"
+    ],
+    "solc": "solc8.23",
+    "rule_sanity": "basic",
+    "verify": "ProxySimulator:WithFallback.spec"
+}

--- a/CVLByExample/UnresolvedCallSummarization/WithFallback/WithFallback.spec
+++ b/CVLByExample/UnresolvedCallSummarization/WithFallback/WithFallback.spec
@@ -1,0 +1,20 @@
+using Proxy as Proxy;
+using Implementation as Implementation;
+
+methods {
+    function callAddition(address,uint32,uint256,uint256) external returns(uint256) envfree;
+}
+
+rule ProxyFallbackNeverRevertsWhenCallingAddition {
+    address proxy;
+    uint32 methodsig;
+    uint256 x;
+    uint256 y;
+
+    require proxy == Proxy;
+    require methodsig == sig:Implementation.addition(uint256,uint256).selector;
+
+    callAddition@withrevert(proxy, methodsig, x, y);
+
+    assert !lastReverted;
+}

--- a/CVLByExample/UnresolvedCallSummarization/WithFallback/WithFallbackSummarized.conf
+++ b/CVLByExample/UnresolvedCallSummarization/WithFallback/WithFallbackSummarized.conf
@@ -1,0 +1,13 @@
+{
+    "files": [
+        "ProxySimulator.sol",
+        "Proxy.sol",
+        "Implementation.sol"
+    ],
+    "link": [
+        "Proxy:_implementation=Implementation"
+    ],
+    "solc": "solc8.23",
+    "rule_sanity": "basic",
+    "verify": "ProxySimulator:WithFallbackSummarized.spec"
+}

--- a/CVLByExample/UnresolvedCallSummarization/WithFallback/WithFallbackSummarized.spec
+++ b/CVLByExample/UnresolvedCallSummarization/WithFallback/WithFallbackSummarized.spec
@@ -1,0 +1,24 @@
+using Proxy as Proxy;
+using Implementation as Implementation;
+
+methods {
+    function callAddition(address,uint32,uint256,uint256) external returns(uint256) envfree;
+    function _._ external => DISPATCH [
+        Proxy._,
+        Implementation._
+    ] default NONDET;
+}
+
+rule ProxyFallbackNeverRevertsWhenCallingAddition {
+    address proxy;
+    uint32 methodsig;
+    uint256 x;
+    uint256 y;
+
+    require proxy == Proxy;
+    require methodsig == sig:Implementation.addition(uint256,uint256).selector;
+
+    callAddition@withrevert(proxy, methodsig, x, y);
+
+    assert !lastReverted;
+}


### PR DESCRIPTION
This is my example of what we did in Safe with the proxy pattern. This example shows both a proxy and that the dispatch list summary now triggers fallback functions as well. This example does not actually work for another reason: The dispatch list does not consider the implementation when the delegatecall does not resolve.

In my opinion we don't need to force the dispatch list fallback example with the proxy pattern. We can think of another example for the proxy (although I'm not sure how if we can't redirect the delegatecalls). For the fallback now being dispatched with dispatch list I don't think we need an example at all. This is more a bugfix than a new feature, it has no new syntax and need no special explanation. I think making a dedicated example for it would be more confusing than helpful and we can clear this out by simply adding a line to the dispatch list example readme that it also considers fallback functions.