### PR TITLE
feat/git-mcp (chat & server) and X badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<div align="center">
+
+[![GitMCP](https://img.shields.io/endpoint?url=https://gitmcp.io/badge/Certora/Examples)](https://gitmcp.io/Certora/Examples)
+[![Twitter Follow](https://img.shields.io/twitter/follow/certorainc?style=social)](https://x.com/certorainc)
+</div>
+
 # Certora Prover and CVL Examples
 This repository contains a collection of examples illustrating CVL usage.
 The specifications are compatible with CVL2.


### PR DESCRIPTION
Adding two new badges to **README.md** to improve discoverability and community engagement.



## Why this change?

GitHub README badges act as a quick, visual TL;DR that guide visitors to the most useful links and metrics for a project. Well-chosen badges are widely considered a best-practice for open-source projects because they increase click-through rates and help convey credibility at a glance. 

## What’s included?

| Badge              | Purpose                                                                                                            |
| ------------------ | ------------------------------------------------------------------------------------------------------------------ |
| **GitMCP Badge**   | 1-click access to this repo’s dedicated MCP & Chat servers, plus a live counter of documentation opens via GitMCP. 
| **Follow Us on X** | Direct link inviting readers to follow Certora’s X (Twitter) account for updates.  

Both badges are rendered directly under the main project title so they’re visible above the fold.

## Implementation details

* Re-used the official GitMCP badge snippet recommended in the GitMCP README.
* Generated the X-follow badge via Shields.io using the pattern `https://img.shields.io/twitter/follow/{handle}?style=for-the-badge`. 

## How to review

1. Open the “Files changed” tab.
2. Click **README.md** and choose **“Preview”** to see the badges rendered in place.
3. Verify that both links open in a new tab and the GitMCP counter increments on first load.

### Screenshot

![Screenshot from 2025-07-08 00-14-36](https://github.com/user-attachments/assets/96af515f-187e-42b6-973e-e0f05b7acc2e)

### Checklist

* [x] Markdown renders without warnings.
* [x] Badge links verified.
* [x] No linting or test regressions.