### PR TITLE
CERT-9252 | Fix sanity failures in induction base for major version 8

### DIFF
--- a/DEFI/ConstantProductPool/contracts/broken/ConstantProductPoolBroken.sol
+++ b/DEFI/ConstantProductPool/contracts/broken/ConstantProductPoolBroken.sol
@@ -38,8 +38,8 @@ contract ConstantProductPool is ERC20 {
     }
 
     constructor(address _token0, address _token1)  {
-        require(token0 != address(0));
-        require(token0 != token1);
+        require(_token0 != address(0));
+        require(_token0 != _token1);
         token0 = _token0;
         token1 = _token1;
         locked = 1;

--- a/DEFI/LiquidityPool/certora/specs/Full.spec
+++ b/DEFI/LiquidityPool/certora/specs/Full.spec
@@ -441,7 +441,7 @@ rule sharesRoundingTripFavoursContract(env e) {
   prove bug fix
 */
 invariant noClientHasSharesWithMoreValueThanDepositedAmount(address a)
-        sharesToAmount(balanceOf(a)) <= depositedAmount()
+        totalSupply() == 0 || sharesToAmount(balanceOf(a)) <= depositedAmount()
 		{
 			preserved with(env e) {
 				require balanceOf(a) + balanceOf(e.msg.sender) < totalSupply();


### PR DESCRIPTION
This PR fixes santity failures on induction base steps of two rules

* runFullPool.conf -> https://vaas-stg.certora.com/output/53900/a7ab7f221da84eb4accea1c95e936803?anonymousKey=e063b8e60bae944b4a9d0d0431999b5bd4b578ea (rule noClientHasSharesWithMoreValueThanDepositedAmount was vacuous)
* runBroken.con -> https://vaas-stg.certora.com/output/53900/c85b8c49fec24d32ac0de00043d7ddd6?anonymousKey=a6c585f91d010a7c13f1c6d8935143b894a0c05d (rule allowanceOfPoolAlwaysZero was vacuous)