### PR TITLE
Add rule verifying flash loans increase share value

### DIFF
--- a/DEFI/LiquidityPool/certora/specs/Full.spec
+++ b/DEFI/LiquidityPool/certora/specs/Full.spec
@@ -254,6 +254,24 @@ rule flashLoanRevertConditions(env e){
     assert isExpectedToRevert <=> lastReverted;
 }
 
+/// Validates that a flash loan generates yield by increase the value of each share (modulo rounding)
+rule flashLoansGenerateYield(address receiver, uint amount) {
+    env e;
+    require e.msg.sender != currentContract;
+    
+    uint assetsBefore = depositedAmount();
+    uint sharesBefore = totalSupply();
+    flashLoan(e, receiver, amount);
+    uint assetsAfter = depositedAmount();
+    uint sharesAfter = totalSupply();
+
+    // The total assets held by the contract must increase, while the number of shares remains constant.
+    // The yield might not be reflected in sharesToAmount due to the rounding.
+
+    assert assetsAfter > assetsBefore;
+    assert sharesAfter == sharesBefore;
+}
+
 /*
 ┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │ Find and show a path for each method.                                                                               │


### PR DESCRIPTION
This is a simple improvement for the liquidity pool example. Adds a new formal rule `flashLoansGenerateYield` verifying that flash‑loan operations increase the pools assets without increasing shares, thereby increase per-share value.

The rule passes: https://prover.certora.com/output/5540961/3c2446f92fc2433391de7b64980129bf?anonymousKey=d877214e0cfbcc8bc489c146436deea8958f9466